### PR TITLE
use map variable passed to onAdd function as the map in metadata funciton

### DIFF
--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -4,26 +4,24 @@ Esri.FeatureLayer.addInitHook(function() {
   var oldOnRemove = L.Util.bind(this.onRemove, this);
   L.Util.bind(this.createNewLayer, this);
 
-  this._metadataLoaded = false;
-
   this.metadata(function(error, response) {
     if(response && response.drawingInfo && !this.options.style){
       this._setRenderers(response);
     }
+
     this._metadataLoaded = true;
-    /* jshint ignore:start */
-    if(this._addToMap){
-      oldOnAdd(map);
-      this._addPointLayer(map);
+    if(this._loadedMap){
+      oldOnAdd(this._loadedMap);
+      this._addPointLayer(this._loadedMap);
     }
-    /* jshint ignore:end */
   }, this);
 
   this.onAdd = function(map){
-    this._addToMap = true;
+
+    this._loadedMap = map;
     if(this._metadataLoaded){
-      oldOnAdd(map);
-      this._addPointLayer(map);
+      oldOnAdd(this._loadedMap);
+      this._addPointLayer(this._loadedMap);
     }
   };
 


### PR DESCRIPTION
Resolves #26 

The map in the metadata function is a little ambiguous and when using Browserify it refers to the map container not the map object.

The map in the onAdd function is passed in as the proper map object when using Browserify so use it instead.