### PR TITLE
add missing grunt-s3 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-karma": "^0.8.3",
     "grunt-releaseable": "0.0.12",
+    "grunt-s3": "^0.2.0-alpha.3",
     "karma": "^0.12.16",
     "karma-chai-sinon": "^0.1.3",
     "karma-chrome-launcher": "^0.1.3",


### PR DESCRIPTION
When I ran npm install, I got an error that the grunt-s3 module was missing.