### PR TITLE
add s3 support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+var fs = require('fs');
+
 module.exports = function(grunt) {
   var browsers = grunt.option('browser') ? grunt.option('browser').split(',') : ['PhantomJS'];
 
@@ -143,6 +145,12 @@ module.exports = function(grunt) {
     }
 
   });
+
+  var awsExists = fs.existsSync(process.env.HOME + '/esri-leaflet-s3.json');
+
+  if (awsExists) {
+    grunt.config.set('aws', grunt.file.readJSON(process.env.HOME + '/esri-leaflet-s3.json'));
+  }
 
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   ],
   "dependencies": {
     "leaflet": "^0.7.0",
-    "esri-leaflet": "1.0.0-rc.5"
+    "esri-leaflet": "^1.0.0-rc.5"
   }
 }


### PR DESCRIPTION
resolves #45 and adds actual support for running `grunt s3`

probably safe to bump your [sample](http://esri.github.io/esri-leaflet/examples/renderers-plugin.html) now.  fyi that the 'v' is gone (which pleases my OCD)

old:
http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/v0.0.1-beta.2/esri-leaflet-renderers.js
new:
http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/0.0.1-beta.3/esri-leaflet-renderers.js