### PR TITLE
update the urls for beta.3 and remove airports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can also find a side by side comparison of the ArcGIS API for JavaScript [he
 
     <!-- Load Esri Leaflet Renderers -->
     <!-- This will hook into Esri Leaflet and draw the predefined Portland Heritage Tree symbols -->
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/v0.0.1-beta.2/esri-leaflet-renderers.js"></script>
+    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/0.0.1-beta.3/esri-leaflet-renderers.js"></script>
 
     <style>
       body {margin:0;padding:0;}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <!-- Load Esri Leaflet Renderers -->
     <!-- This will hook into Esri Leaflet and draw World Regions using symbols defined in the service-->
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/v0.0.1-beta.2/esri-leaflet-renderers.js"></script>
+    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/0.0.1-beta.3/esri-leaflet-renderers.js"></script>
 
     <style>
       body {margin:0;padding:0;}

--- a/spec/comparisons.html
+++ b/spec/comparisons.html
@@ -10,7 +10,7 @@
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
 
     <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet.js"></script>
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/v0.0.1-beta.2/esri-leaflet-renderers.js"></script>
+    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/0.0.1-beta.3/esri-leaflet-renderers.js"></script>
 
     <link rel="stylesheet" href="http://js.arcgis.com/3.13/esri/css/esri.css">
     <script src="http://js.arcgis.com/3.13/"></script>
@@ -47,14 +47,6 @@
         rendererType: 'Simple',
         lat: 38,
         lon: -95,
-        zoomLevel: 4
-      }, {
-        url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Airports/FeatureServer/0',
-        title: 'USA Airports',
-        geoType: 'Point',
-        rendererType: 'Classbreaks',
-        lat: 34,
-        lon: -97,
         zoomLevel: 4
       }, {
         url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_States_Generalized/FeatureServer/0',


### PR DESCRIPTION
Updated CDN links to beta 3.

The airports layer seems to have disappeared? Maybe it is temporary but I could not find the layer in Esri Featured Content - Transportation.