### PR TITLE
tie dash array pattern to weight of line

### DIFF
--- a/src/Symbols/LineSymbol.js
+++ b/src/Symbols/LineSymbol.js
@@ -12,14 +12,10 @@ EsriLeafletRenderers.LineSymbol = EsriLeafletRenderers.Symbol.extend({
     //set the defaults that show up on arcgis online
     this._styles.lineCap = 'butt';
     this._styles.lineJoin = 'miter';
-
+    this._styles.fill = false;
 
     if (!this._symbolJson){
       return;
-    }
-
-    if(this._symbolJson.width){
-      this._styles.weight = this.pixelValue(this._symbolJson.width);
     }
 
     if(this._symbolJson.color ){
@@ -27,24 +23,34 @@ EsriLeafletRenderers.LineSymbol = EsriLeafletRenderers.Symbol.extend({
       this._styles.opacity = this.alphaValue(this._symbolJson.color);
     }
 
-    //usuing dash patterns pulled from arcgis online (converted to pixels)
-    switch(this._symbolJson.style){
-      case 'esriSLSDash':
-        //4,3
-        this._styles.dashArray = '5,4';
-        break;
-      case 'esriSLSDot':
-        //1,3
-        this._styles.dashArray = '1,4';
-        break;
-      case 'esriSLSDashDot':
-        //8,3,1,3
-        this._styles.dashArray = '11,4,1,4';
-        break;
-      case 'esriSLSDashDotDot':
-        //8,3,1,3,1,3
-        this._styles.dashArray = '11,4,1,4,1,4';
-        break;
+    if(this._symbolJson.width){
+      this._styles.weight = this.pixelValue(this._symbolJson.width);
+      
+      var dashValues = [];
+
+      switch(this._symbolJson.style){
+        case 'esriSLSDash':
+          dashValues = [4,3];
+          break;
+        case 'esriSLSDot':
+          dashValues = [1,3];
+          break;
+        case 'esriSLSDashDot':
+          dashValues = [8,3,1,3];
+          break;
+        case 'esriSLSDashDotDot':
+          dashValues = [8,3,1,3,1,3];
+          break;
+      }
+
+      //use the dash values and the line weight to set dash array
+      if (dashValues.length > 0) {
+        for (var i = 0; i < dashValues.length; i++){
+          dashValues[i] *= this._styles.weight;
+        }
+
+        this._styles.dashArray = dashValues.join(',');
+      }
     }
   },
 

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -14,7 +14,10 @@ EsriLeafletRenderers.PolygonSymbol = EsriLeafletRenderers.Symbol.extend({
   _fillStyles: function(){
     //set the fill for the polygon
     if (this._symbolJson) {
-      if (this._symbolJson.color) {
+      if (this._symbolJson.color &&
+          //don't fill polygon if type is not supported
+          EsriLeafletRenderers.PolygonSymbol.POLYGONTYPES.indexOf(this._symbolJson.style >= 0)) {
+
         this._styles.fillColor = this.colorValue(this._symbolJson.color);
         this._styles.fillOpacity = this.alphaValue(this._symbolJson.color);
       } else {

--- a/src/Symbols/Symbol.js
+++ b/src/Symbols/Symbol.js
@@ -9,7 +9,8 @@ EsriLeafletRenderers.Symbol = L.Class.extend({
 
   //the geojson values returned are in points
   pixelValue: function(pointValue){
-    return pointValue * 1.3333333333333;
+    //round the values so that pixel values are always integers
+    return Math.round(pointValue * 1.3333333333333);
   },
 
   //color is an array [r,g,b,a]


### PR DESCRIPTION
I did not test with varying stroke widths when testing the dash patterns, this addresses that oversight.

If a polygon has an unsupported fill type, set opacity to 0 so it is not filled at all.
Add additional default for line paths: JS API uses `fill='none'`
Round the pixel values so we are using integers.

resolves #43
