### PR TITLE
Copy styles from line symbol over to polygon before setting polygon styles

### DIFF
--- a/spec/Symbols/PolygonSymbolSpec.js
+++ b/spec/Symbols/PolygonSymbolSpec.js
@@ -32,6 +32,7 @@
         var symbol = L.esri.Renderers.polygonSymbol(solidPolygon);
         var styles = symbol.style();
         
+        expect(styles.fill).to.be.eq(true);
         expect(styles.fillColor).to.be.eq(symbolHelper.colorValue(solidPolygon.color));
         expect(styles.fillOpacity).to.be.eq(symbolHelper.alphaValue(solidPolygon.color));
         expect(styles.color).to.be.eq(symbolHelper.colorValue(solidPolygon.outline.color));

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -12,21 +12,8 @@ EsriLeafletRenderers.PolygonSymbol = EsriLeafletRenderers.Symbol.extend({
   },
 
   _fillStyles: function(){
-    //set the fill for the polygon
-    if (this._symbolJson) {
-      if (this._symbolJson.color &&
-          //don't fill polygon if type is not supported
-          EsriLeafletRenderers.PolygonSymbol.POLYGONTYPES.indexOf(this._symbolJson.style >= 0)) {
-
-        this._styles.fillColor = this.colorValue(this._symbolJson.color);
-        this._styles.fillOpacity = this.alphaValue(this._symbolJson.color);
-      } else {
-        this._styles.fillOpacity = 0;
-      }
-    }
-
-    if(this._lineStyles){
-      if(this._lineStyles.weight === 0){
+    if (this._lineStyles) {
+      if (this._lineStyles.weight === 0){
         //when weight is 0, setting the stroke to false can still look bad
         //(gaps between the polygons)
         this._styles.stroke = false;
@@ -37,6 +24,22 @@ EsriLeafletRenderers.PolygonSymbol = EsriLeafletRenderers.Symbol.extend({
         }
       }
     }
+
+    //set the fill for the polygon
+    if (this._symbolJson) {
+      if (this._symbolJson.color &&
+          //don't fill polygon if type is not supported
+          EsriLeafletRenderers.PolygonSymbol.POLYGONTYPES.indexOf(this._symbolJson.style >= 0)) {
+
+        this._styles.fill = true;
+        this._styles.fillColor = this.colorValue(this._symbolJson.color);
+        this._styles.fillOpacity = this.alphaValue(this._symbolJson.color);
+      } else {
+        this._styles.fill = false;
+        this._styles.fillOpacity = 0;
+      }
+    }
+
   },
 
   style: function(feature, visualVariables) {

--- a/src/Symbols/Symbol.js
+++ b/src/Symbols/Symbol.js
@@ -9,8 +9,7 @@ EsriLeafletRenderers.Symbol = L.Class.extend({
 
   //the geojson values returned are in points
   pixelValue: function(pointValue){
-    //round the values so that pixel values are always integers
-    return Math.round(pointValue * 1.3333333333333);
+    return pointValue * 1.333;
   },
 
   //color is an array [r,g,b,a]


### PR DESCRIPTION
Set the fill explicitly in polygon styles instead of using default value to override whatever is set from line symbol.

Removed rounding from pixelValue, I added it in on the last commit and I feel that it is going to come back and haunt me.  I reduced the decimal places in the calculation because it was a little extreme.

This should resolve the fill problem in #54 