### PR TITLE
update to esri-leaflet 1.0.0 stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet-renderers",
-  "version": "0.0.1-beta.3",
+  "version": "1.0.0",
   "description": "Esri Rendering plugin for Leaflet.",
   "homepage": "https://github.com/Esri/esri-leaflet-renderers",
   "main": "dist/esri-leaflet-renderers.js",
@@ -41,6 +41,6 @@
   ],
   "dependencies": {
     "leaflet": "^0.7.0",
-    "esri-leaflet": "^1.0.0-rc.5"
+    "esri-leaflet": "^1.0.0"
   }
 }

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -5,6 +5,9 @@ Esri.FeatureLayer.addInitHook(function() {
   L.Util.bind(this.createNewLayer, this);
 
   this.metadata(function(error, response) {
+    if(error) {
+      return;
+    }
     if(response && response.drawingInfo && !this.options.style){
       this._setRenderers(response);
     }


### PR DESCRIPTION
@jgravois first step in getting our own stable release for parity with esri-leaflet 1.0.0.  I would like to tackle a few of the issues for this release as well.