### PR TITLE
moving tests to run via npm instead of grunt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+sudo: false
+node_js:
+  - "0.12"
+cache:
+  directories:
+    - node_modules

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,8 +13,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'node_modules/esri-leaflet/node_modules/leaflet/dist/leaflet.css',
-      'node_modules/esri-leaflet/node_modules/leaflet/dist/leaflet.js',
+      'node_modules/leaflet/dist/leaflet.css',
+      'node_modules/leaflet/dist/leaflet.js',
       'node_modules/esri-leaflet/dist/esri-leaflet.js',
       'node_modules/leaflet-shape-markers/dist/leaflet-shape-markers.min.js',
       'spec/**/*Spec.js',

--- a/package.json
+++ b/package.json
@@ -32,13 +32,8 @@
     "karma-mocha-reporter": "^0.2.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-safari-launcher": "^0.1.1",
-<<<<<<< Updated upstream
-    "karma-sauce-launcher": "^0.2.10"
-=======
-    "karma-sauce-launcher": "^0.2.10",
     "mkdirp": "^0.5.1",
     "semistandard": "^6.1.2"
->>>>>>> Stashed changes
   },
   "dependencies": {
      "esri-leaflet": "Esri/esri-leaflet.git#leaflet-1.0",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,6 @@
   "license": "Apache",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-uglify": "^0.5.1",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-karma": "^0.8.3",
     "karma": "^0.12.16",
     "karma-chai-sinon": "^0.1.3",
     "karma-chrome-launcher": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "\"esri-leaflet plugin for rendering\"",
   "main": "EsriLeafletRenderers.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "node scripts/install.js"
+    "prebuild": "mkdirp dist",
+    "build": "./scripts/build.js",
+    "lint": "semistandard src/**/*.js",
+    "release": "./scripts/release.sh",
+    "test": "npm run lint && karma start"
   },
   "author": "Rachel Nehmer <rnehmer@esri.com>",
   "contributors": [
@@ -29,7 +32,13 @@
     "karma-mocha-reporter": "^0.2.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-safari-launcher": "^0.1.1",
+<<<<<<< Updated upstream
     "karma-sauce-launcher": "^0.2.10"
+=======
+    "karma-sauce-launcher": "^0.2.10",
+    "mkdirp": "^0.5.1",
+    "semistandard": "^6.1.2"
+>>>>>>> Stashed changes
   },
   "dependencies": {
      "esri-leaflet": "Esri/esri-leaflet.git#leaflet-1.0",

--- a/src/Renderers/ClassBreaksRenderer.js
+++ b/src/Renderers/ClassBreaksRenderer.js
@@ -1,20 +1,19 @@
 EsriLeafletRenderers.ClassBreaksRenderer = EsriLeafletRenderers.Renderer.extend({
-
-  initialize: function(rendererJson, options){
+  initialize: function (rendererJson, options) {
     EsriLeafletRenderers.Renderer.prototype.initialize.call(this, rendererJson, options);
     this._field = this._rendererJson.field;
     this._createSymbols();
   },
 
-  _createSymbols: function(){
-    var symbol,
-        classbreaks = this._rendererJson.classBreakInfos;
+  _createSymbols: function () {
+    var symbol;
+    var classbreaks = this._rendererJson.classBreakInfos;
 
     this._symbols = [];
 
-    //create a symbol for each class break
-    for (var i = classbreaks.length  - 1; i >= 0; i--){
-      if(this.options.proportionalPolygon && this._rendererJson.backgroundFillSymbol){
+    // create a symbol for each class break
+    for (var i = classbreaks.length - 1; i >= 0; i--) {
+      if (this.options.proportionalPolygon && this._rendererJson.backgroundFillSymbol) {
         symbol = this._newSymbol(this._rendererJson.backgroundFillSymbol);
       } else {
         symbol = this._newSymbol(classbreaks[i].symbol);
@@ -22,22 +21,22 @@ EsriLeafletRenderers.ClassBreaksRenderer = EsriLeafletRenderers.Renderer.extend(
       symbol.val = classbreaks[i].classMaxValue;
       this._symbols.push(symbol);
     }
-    //sort the symbols in ascending value
-    this._symbols.sort(function(a, b){
+    // sort the symbols in ascending value
+    this._symbols.sort(function (a, b) {
       return a.val > b.val ? 1 : -1;
     });
     this._createDefaultSymbol();
     this._maxValue = this._symbols[this._symbols.length - 1].val;
   },
 
-  _getSymbol: function(feature){
+  _getSymbol: function (feature) {
     var val = feature.properties[this._field];
-    if(val > this._maxValue){
+    if (val > this._maxValue) {
       return this._defaultSymbol;
     }
     var symbol = this._symbols[0];
-    for (var i = this._symbols.length - 1; i >= 0; i--){
-      if(val > this._symbols[i].val){
+    for (var i = this._symbols.length - 1; i >= 0; i--) {
+      if (val > this._symbols[i].val) {
         break;
       }
       symbol = this._symbols[i];
@@ -46,6 +45,6 @@ EsriLeafletRenderers.ClassBreaksRenderer = EsriLeafletRenderers.Renderer.extend(
   }
 });
 
-EsriLeafletRenderers.classBreaksRenderer = function(rendererJson, options){
+EsriLeafletRenderers.classBreaksRenderer = function (rendererJson, options) {
   return new EsriLeafletRenderers.ClassBreaksRenderer(rendererJson, options);
 };

--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -1,65 +1,63 @@
 EsriLeafletRenderers.Renderer = L.Class.extend({
-
   options: {
     proportionalPolygon: false,
     clickable: true
   },
 
-  initialize: function(rendererJson, options){
+  initialize: function (rendererJson, options) {
     this._rendererJson = rendererJson;
     this._pointSymbols = false;
     this._symbols = [];
     L.Util.setOptions(this, options);
   },
 
-
-  _createDefaultSymbol: function(){
-    if(this._rendererJson.defaultSymbol){
+  _createDefaultSymbol: function () {
+    if (this._rendererJson.defaultSymbol) {
       this._defaultSymbol = this._newSymbol(this._rendererJson.defaultSymbol);
     }
   },
 
-  _newSymbol: function(symbolJson){
-    if(symbolJson.type === 'esriSMS' || symbolJson.type === 'esriPMS'){
+  _newSymbol: function (symbolJson) {
+    if (symbolJson.type === 'esriSMS' || symbolJson.type === 'esriPMS') {
       this._pointSymbols = true;
       return EsriLeafletRenderers.pointSymbol(symbolJson, this.options);
     }
-    if(symbolJson.type === 'esriSLS'){
+    if (symbolJson.type === 'esriSLS') {
       return EsriLeafletRenderers.lineSymbol(symbolJson);
     }
-    if(symbolJson.type === 'esriSFS'){
+    if (symbolJson.type === 'esriSFS') {
       return EsriLeafletRenderers.polygonSymbol(symbolJson);
     }
   },
 
-  _getSymbol: function(){
-    //override
+  _getSymbol: function () {
+    // override
   },
 
-  attachStylesToLayer: function(layer){
-    if(this._pointSymbols){
+  attachStylesToLayer: function (layer) {
+    if (this._pointSymbols) {
       layer.options.pointToLayer = L.Util.bind(this.pointToLayer, this);
     } else {
       layer.options.style = L.Util.bind(this.style, this);
     }
   },
 
-  pointToLayer: function(geojson, latlng){
+  pointToLayer: function (geojson, latlng) {
     var sym = this._getSymbol(geojson);
-    if(sym){
+    if (sym) {
       return sym.pointToLayer(geojson, latlng);
     }
-    //invisible symbology
+    // invisible symbology
     return L.circleMarker(latlng, {radius: 0});
   },
 
-  style: function(feature){
-    //find the symbol to represent this feature
+  style: function (feature) {
+    // find the symbol to represent this feature
     var sym = this._getSymbol(feature);
-    if(sym){
+    if (sym) {
       return sym.style(feature);
-    }else{
-      //invisible symbology
+    } else {
+      // invisible symbology
       return {opacity: 0, fillOpacity: 0};
     }
   }

--- a/src/Renderers/SimpleRenderer.js
+++ b/src/Renderers/SimpleRenderer.js
@@ -1,21 +1,20 @@
 EsriLeafletRenderers.SimpleRenderer = EsriLeafletRenderers.Renderer.extend({
-
-  initialize: function(rendererJson, options){
+  initialize: function (rendererJson, options) {
     EsriLeafletRenderers.Renderer.prototype.initialize.call(this, rendererJson, options);
     this._createSymbol();
   },
 
-  _createSymbol: function(){
-    if(this._rendererJson.symbol){
+  _createSymbol: function () {
+    if (this._rendererJson.symbol) {
       this._symbols.push(this._newSymbol(this._rendererJson.symbol));
     }
   },
 
-  _getSymbol: function(){
+  _getSymbol: function () {
     return this._symbols[0];
   }
 });
 
-EsriLeafletRenderers.simpleRenderer = function(rendererJson, options){
+EsriLeafletRenderers.simpleRenderer = function (rendererJson, options) {
   return new EsriLeafletRenderers.SimpleRenderer(rendererJson, options);
 };

--- a/src/Renderers/UniqueValueRenderer.js
+++ b/src/Renderers/UniqueValueRenderer.js
@@ -1,18 +1,18 @@
 EsriLeafletRenderers.UniqueValueRenderer = EsriLeafletRenderers.Renderer.extend({
-
-  initialize: function(rendererJson, options){
+  initialize: function (rendererJson, options) {
     EsriLeafletRenderers.Renderer.prototype.initialize.call(this, rendererJson, options);
 
-    //what to do when there are other fields?
+    // what to do when there are other fields?
     this._field = this._rendererJson.field1;
     this._createSymbols();
   },
 
-  _createSymbols: function(){
-    var symbol, uniques = this._rendererJson.uniqueValueInfos;
+  _createSymbols: function () {
+    var symbol;
+    var uniques = this._rendererJson.uniqueValueInfos;
 
-    //create a symbol for each unique value
-    for (var i = uniques.length  - 1; i >= 0; i--){
+    // create a symbol for each unique value
+    for (var i = uniques.length - 1; i >= 0; i--) {
       symbol = this._newSymbol(uniques[i].symbol);
       symbol.val = uniques[i].value;
       this._symbols.push(symbol);
@@ -21,21 +21,21 @@ EsriLeafletRenderers.UniqueValueRenderer = EsriLeafletRenderers.Renderer.extend(
   },
 
   /* jshint ignore:start */
-  _getSymbol: function(feature){
+  _getSymbol: function (feature) {
     var val = feature.properties[this._field];
     var symbol = this._defaultSymbol;
-    for (var i = this._symbols.length  - 1; i >= 0; i--){
-      //using the === operator does not work if the field
-      //of the unique renderer is not a string
-      if(this._symbols[i].val == val){
+    for (var i = this._symbols.length - 1; i >= 0; i--) {
+      // using the === operator does not work if the field
+      // of the unique renderer is not a string
+      if (this._symbols[i].val === val) {
         symbol = this._symbols[i];
       }
     }
     return symbol;
   }
-  /* jshint ignore:end */
+/* jshint ignore:end */
 });
 
-EsriLeafletRenderers.uniqueValueRenderer = function(rendererJson, options){
+EsriLeafletRenderers.uniqueValueRenderer = function (rendererJson, options) {
   return new EsriLeafletRenderers.UniqueValueRenderer(rendererJson, options);
 };

--- a/src/Symbols/LineSymbol.js
+++ b/src/Symbols/LineSymbol.js
@@ -1,57 +1,56 @@
 EsriLeafletRenderers.LineSymbol = EsriLeafletRenderers.Symbol.extend({
   statics: {
-    //Not implemented 'esriSLSNull'
-    LINETYPES:  ['esriSLSDash','esriSLSDot','esriSLSDashDotDot','esriSLSDashDot','esriSLSSolid']
+    // Not implemented 'esriSLSNull'
+    LINETYPES: ['esriSLSDash', 'esriSLSDot', 'esriSLSDashDotDot', 'esriSLSDashDot', 'esriSLSSolid']
   },
-  initialize: function(symbolJson){
+  initialize: function (symbolJson) {
     EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson);
     this._fillStyles();
   },
 
-  _fillStyles: function(){
-    //set the defaults that show up on arcgis online
+  _fillStyles: function () {
+    // set the defaults that show up on arcgis online
     this._styles.lineCap = 'butt';
     this._styles.lineJoin = 'miter';
 
-
-    if (!this._symbolJson){
+    if (!this._symbolJson) {
       return;
     }
 
-    if(this._symbolJson.width){
+    if (this._symbolJson.width) {
       this._styles.weight = this.pixelValue(this._symbolJson.width);
     }
 
-    if(this._symbolJson.color ){
+    if (this._symbolJson.color) {
       this._styles.color = this.colorValue(this._symbolJson.color);
       this._styles.opacity = this.alphaValue(this._symbolJson.color);
     }
 
-    //usuing dash patterns pulled from arcgis online (converted to pixels)
-    switch(this._symbolJson.style){
+    // usuing dash patterns pulled from arcgis online (converted to pixels)
+    switch (this._symbolJson.style) {
       case 'esriSLSDash':
-        //4,3
+        // 4,3
         this._styles.dashArray = '5,4';
         break;
       case 'esriSLSDot':
-        //1,3
+        // 1,3
         this._styles.dashArray = '1,4';
         break;
       case 'esriSLSDashDot':
-        //8,3,1,3
+        // 8,3,1,3
         this._styles.dashArray = '11,4,1,4';
         break;
       case 'esriSLSDashDotDot':
-        //8,3,1,3,1,3
+        // 8,3,1,3,1,3
         this._styles.dashArray = '11,4,1,4,1,4';
         break;
     }
   },
 
-  style: function(){
+  style: function () {
     return this._styles;
   }
 });
-EsriLeafletRenderers.lineSymbol = function(symbolJson){
+EsriLeafletRenderers.lineSymbol = function (symbolJson) {
   return new EsriLeafletRenderers.LineSymbol(symbolJson);
 };

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -1,14 +1,14 @@
 EsriLeafletRenderers.PointSymbol = EsriLeafletRenderers.Symbol.extend({
   statics: {
-    MARKERTYPES:  ['esriSMSCircle','esriSMSCross', 'esriSMSDiamond', 'esriSMSSquare', 'esriSMSX', 'esriPMS']
+    MARKERTYPES: ['esriSMSCircle', 'esriSMSCross', 'esriSMSDiamond', 'esriSMSSquare', 'esriSMSX', 'esriPMS']
   },
-  initialize: function(symbolJson, options){
+  initialize: function (symbolJson, options) {
     EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson);
-    if(options) {
+    if (options) {
       this.serviceUrl = options.url;
     }
-    if(symbolJson){
-      if(symbolJson.type === 'esriPMS'){
+    if (symbolJson) {
+      if (symbolJson.type === 'esriPMS') {
         this._createIcon();
       } else {
         this._fillStyles();
@@ -16,26 +16,26 @@ EsriLeafletRenderers.PointSymbol = EsriLeafletRenderers.Symbol.extend({
     }
   },
 
-  _fillStyles: function(){
-    if(this._symbolJson.outline && this._symbolJson.size > 0){
+  _fillStyles: function () {
+    if (this._symbolJson.outline && this._symbolJson.size > 0) {
       this._styles.stroke = true;
       this._styles.weight = this.pixelValue(this._symbolJson.outline.width);
       this._styles.color = this.colorValue(this._symbolJson.outline.color);
       this._styles.opacity = this.alphaValue(this._symbolJson.outline.color);
-    }else{
+    } else {
       this._styles.stroke = false;
     }
-    if(this._symbolJson.color){
+    if (this._symbolJson.color) {
       this._styles.fillColor = this.colorValue(this._symbolJson.color);
       this._styles.fillOpacity = this.alphaValue(this._symbolJson.color);
     }
 
-    if(this._symbolJson.style === 'esriSMSCircle'){
+    if (this._symbolJson.style === 'esriSMSCircle') {
       this._styles.radius = this.pixelValue(this._symbolJson.size) / 2.0;
     }
   },
 
-  _createIcon: function(){
+  _createIcon: function () {
     var height = this.pixelValue(this._symbolJson.height);
     var width = this.pixelValue(this._symbolJson.width);
     var xOffset = width / 2.0 + this.pixelValue(this._symbolJson.xoffset);
@@ -48,14 +48,14 @@ EsriLeafletRenderers.PointSymbol = EsriLeafletRenderers.Symbol.extend({
       iconAnchor: [xOffset, yOffset]
     });
   },
-  pointToLayer: function(geojson, latlng){
-    if (this._symbolJson.type === 'esriPMS'){
+  pointToLayer: function (geojson, latlng) {
+    if (this._symbolJson.type === 'esriPMS') {
       return L.marker(latlng, {icon: this.icon});
     }
 
     var size = this.pixelValue(this._symbolJson.size);
 
-    switch(this._symbolJson.style){
+    switch (this._symbolJson.style) {
       case 'esriSMSSquare':
         return L.squareMarker(latlng, size, this._styles);
       case 'esriSMSDiamond':
@@ -68,6 +68,6 @@ EsriLeafletRenderers.PointSymbol = EsriLeafletRenderers.Symbol.extend({
     return L.circleMarker(latlng, this._styles);
   }
 });
-EsriLeafletRenderers.pointSymbol = function(symbolJson, options){
+EsriLeafletRenderers.pointSymbol = function (symbolJson, options) {
   return new EsriLeafletRenderers.PointSymbol(symbolJson, options);
 };

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -1,41 +1,41 @@
 EsriLeafletRenderers.PolygonSymbol = EsriLeafletRenderers.Symbol.extend({
   statics: {
-    //not implemented: 'esriSFSBackwardDiagonal','esriSFSCross','esriSFSDiagonalCross','esriSFSForwardDiagonal','esriSFSHorizontal','esriSFSNull','esriSFSVertical'
-    POLYGONTYPES:  ['esriSFSSolid']
+    // not implemented: 'esriSFSBackwardDiagonal','esriSFSCross','esriSFSDiagonalCross','esriSFSForwardDiagonal','esriSFSHorizontal','esriSFSNull','esriSFSVertical'
+    POLYGONTYPES: ['esriSFSSolid']
   },
-  initialize: function(symbolJson){
+  initialize: function (symbolJson) {
     EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson);
-    if (symbolJson){
+    if (symbolJson) {
       this._lineStyles = EsriLeafletRenderers.lineSymbol(symbolJson.outline).style();
       this._fillStyles();
     }
   },
 
-  _fillStyles: function(){
-    //set the fill for the polygon
-    if (this._symbolJson && this._symbolJson.color){
+  _fillStyles: function () {
+    // set the fill for the polygon
+    if (this._symbolJson && this._symbolJson.color) {
       this._styles.fillColor = this.colorValue(this._symbolJson.color);
       this._styles.fillOpacity = this.alphaValue(this._symbolJson.color);
     }
 
-    if(this._lineStyles){
-      if(this._lineStyles.weight === 0){
-        //when weight is 0, setting the stroke to false can still look bad
-        //(gaps between the polygons)
+    if (this._lineStyles) {
+      if (this._lineStyles.weight === 0) {
+        // when weight is 0, setting the stroke to false can still look bad
+        // (gaps between the polygons)
         this._styles.stroke = false;
       } else {
-        //copy the line symbol styles into this symbol's styles
-        for (var styleAttr in this._lineStyles){
+        // copy the line symbol styles into this symbol's styles
+        for (var styleAttr in this._lineStyles) {
           this._styles[styleAttr] = this._lineStyles[styleAttr];
         }
       }
     }
   },
 
-  style: function() {
+  style: function () {
     return this._styles;
   }
 });
-EsriLeafletRenderers.polygonSymbol = function(symbolJson){
+EsriLeafletRenderers.polygonSymbol = function (symbolJson) {
   return new EsriLeafletRenderers.PolygonSymbol(symbolJson);
 };

--- a/src/Symbols/Symbol.js
+++ b/src/Symbols/Symbol.js
@@ -1,22 +1,21 @@
 EsriLeafletRenderers.Symbol = L.Class.extend({
-
-  initialize: function(symbolJson){
+  initialize: function (symbolJson) {
     this._symbolJson = symbolJson;
     this.val = null;
     this._styles = {};
   },
 
-  //the geojson values returned are in points
-  pixelValue: function(pointValue){
+  // the geojson values returned are in points
+  pixelValue: function (pointValue) {
     return pointValue * 1.3333333333333;
   },
 
-  //color is an array [r,g,b,a]
-  colorValue: function(color){
+  // color is an array [r,g,b,a]
+  colorValue: function (color) {
     return 'rgb(' + color[0] + ',' + color[1] + ',' + color[2] + ')';
   },
 
-  alphaValue: function(color){
+  alphaValue: function (color) {
     return color[3] / 255.0;
   }
 });


### PR DESCRIPTION
figured we shouldn't bother using travis until **after** we switch to running tests directly in node.
the vast majority of the file changes here are linting in an attempt of getting us closer to being able to run the new tests succesfully.

it seems sensible to me to merge into `esri-leaflet-2.0.0` and continue housekeeping, but if you disagree, i don't have my heart set on it.  (i'm also happy to rebase and squash once everything looks good)