### PR TITLE
update feature layer initialization for samples

### DIFF
--- a/debug/sample.html
+++ b/debug/sample.html
@@ -49,7 +49,7 @@
       L.esri.basemapLayer('Streets').addTo(map);
 
       //draw the predefined Portland Heritage Tree symbols
-      L.esri.featureLayer('http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0').addTo(map);
+      L.esri.featureLayer({url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'}).addTo(map);
     </script>
 
   </body>

--- a/spec/sample.html
+++ b/spec/sample.html
@@ -10,7 +10,7 @@
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
 
     <!-- Load Esri Leaflet from CDN -->
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet.js"></script>
+    <script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js"></script>
 
     <!-- Load Esri Leaflet Renderers -->
     <!-- This will hook into Esri Leaflet and draw the predefined Portland Heritage Tree symbols -->
@@ -29,7 +29,7 @@
       var map = L.map('map').setView([45.526, -122.667], 13);
 
       L.esri.basemapLayer('Streets').addTo(map);
-      L.esri.featureLayer('http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0').addTo(map);
+      L.esri.featureLayer({url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'}).addTo(map);
     </script>
 
   </body>


### PR DESCRIPTION
For the samples that are loading esri-leaflet-renderers locally, update to esri-leaflet 1.0.0 initialization, https://github.com/Esri/esri-leaflet/releases/tag/v1.0.0.  