### PR TITLE
apply layer transparency to symbols if defined

### DIFF
--- a/spec/Renderers/UniqueValueRendererSpec.js
+++ b/spec/Renderers/UniqueValueRendererSpec.js
@@ -13,7 +13,7 @@
           "outline":{  
             "type":"esriSLS",
             "style":"esriSLSSolid",
-            "color":[0, 0, 0, 255],
+            "color":[0, 0, 0, 51],
             "width":1
           }
         },
@@ -66,6 +66,24 @@
     it("should create three symbols", function () {
       var renderer = L.esri.Renderers.uniqueValueRenderer(rendererJson);
       expect(renderer._symbols.length).to.be.eq(3);
+    });
+
+    describe("symbol transparency", function () {
+      it("should be equal to symbol value when no layer transparency defined", function() {
+        var renderer = L.esri.Renderers.uniqueValueRenderer(rendererJson);
+        expect(renderer._symbols[0]._styles.fillOpacity).to.be.eq(128/255.0);
+        expect(renderer._symbols[0]._lineStyles.opacity).to.be.eq(1);
+        expect(renderer._defaultSymbol._styles.fillOpacity).to.be.eq(64/255.0);
+        expect(renderer._defaultSymbol._lineStyles.opacity).to.be.eq(51/255.0);
+      });
+
+      it("should be equal to symbol value with transparency applied when defined", function() {
+        var renderer = L.esri.Renderers.uniqueValueRenderer(rendererJson, {layerTransparency: 75});
+        expect(renderer._symbols[0]._styles.fillOpacity).to.be.eq(128/255.0 * .25);
+        expect(renderer._symbols[0]._lineStyles.opacity).to.be.eq(.25);
+        expect(renderer._defaultSymbol._styles.fillOpacity).to.be.eq(64/255.0 * .25);
+        expect(renderer._defaultSymbol._lineStyles.opacity).to.be.eq(51/255.0 * .25);
+      });
     });
 
     it("should create a default symbol", function () {

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -155,6 +155,9 @@ Esri.FeatureLayer.addInitHook(function() {
         url: this.url ? this.url : this._service.options.url,
         token: this._service.options.token
     };
+    if(geojson.drawingInfo.transparency) {
+      options.layerTransparency = geojson.drawingInfo.transparency;
+    }
 
     switch(rendererInfo.type){
       case 'classBreaks':

--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -36,10 +36,10 @@ EsriLeafletRenderers.Renderer = L.Class.extend({
       return EsriLeafletRenderers.pointSymbol(symbolJson, this.options);
     }
     if(symbolJson.type === 'esriSLS'){
-      return EsriLeafletRenderers.lineSymbol(symbolJson);
+      return EsriLeafletRenderers.lineSymbol(symbolJson, this.options);
     }
     if(symbolJson.type === 'esriSFS'){
-      return EsriLeafletRenderers.polygonSymbol(symbolJson);
+      return EsriLeafletRenderers.polygonSymbol(symbolJson, this.options);
     }
   },
 

--- a/src/Symbols/LineSymbol.js
+++ b/src/Symbols/LineSymbol.js
@@ -3,8 +3,8 @@ EsriLeafletRenderers.LineSymbol = EsriLeafletRenderers.Symbol.extend({
     //Not implemented 'esriSLSNull'
     LINETYPES:  ['esriSLSDash','esriSLSDot','esriSLSDashDotDot','esriSLSDashDot','esriSLSSolid']
   },
-  initialize: function(symbolJson){
-    EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson);
+  initialize: function(symbolJson, options){
+    EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson, options);
     this._fillStyles();
   },
 
@@ -73,6 +73,6 @@ EsriLeafletRenderers.LineSymbol = EsriLeafletRenderers.Symbol.extend({
     return this._styles;
   }
 });
-EsriLeafletRenderers.lineSymbol = function(symbolJson){
-  return new EsriLeafletRenderers.LineSymbol(symbolJson);
+EsriLeafletRenderers.lineSymbol = function(symbolJson, options){
+  return new EsriLeafletRenderers.LineSymbol(symbolJson, options);
 };

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -3,7 +3,7 @@ EsriLeafletRenderers.PointSymbol = EsriLeafletRenderers.Symbol.extend({
     MARKERTYPES:  ['esriSMSCircle','esriSMSCross', 'esriSMSDiamond', 'esriSMSSquare', 'esriSMSX', 'esriPMS']
   },
   initialize: function(symbolJson, options){
-    EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson);
+    EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson, options);
     if(options) {
       this.serviceUrl = options.url;
     }

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -3,10 +3,10 @@ EsriLeafletRenderers.PolygonSymbol = EsriLeafletRenderers.Symbol.extend({
     //not implemented: 'esriSFSBackwardDiagonal','esriSFSCross','esriSFSDiagonalCross','esriSFSForwardDiagonal','esriSFSHorizontal','esriSFSNull','esriSFSVertical'
     POLYGONTYPES:  ['esriSFSSolid']
   },
-  initialize: function(symbolJson){
-    EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson);
+  initialize: function(symbolJson, options){
+    EsriLeafletRenderers.Symbol.prototype.initialize.call(this, symbolJson, options);
     if (symbolJson){
-      this._lineStyles = EsriLeafletRenderers.lineSymbol(symbolJson.outline).style();
+      this._lineStyles = EsriLeafletRenderers.lineSymbol(symbolJson.outline, options).style();
       this._fillStyles();
     }
   },
@@ -53,6 +53,6 @@ EsriLeafletRenderers.PolygonSymbol = EsriLeafletRenderers.Symbol.extend({
     return this._styles;
   }
 });
-EsriLeafletRenderers.polygonSymbol = function(symbolJson){
-  return new EsriLeafletRenderers.PolygonSymbol(symbolJson);
+EsriLeafletRenderers.polygonSymbol = function(symbolJson, options){
+  return new EsriLeafletRenderers.PolygonSymbol(symbolJson, options);
 };

--- a/src/Symbols/Symbol.js
+++ b/src/Symbols/Symbol.js
@@ -1,10 +1,14 @@
 EsriLeafletRenderers.Symbol = L.Class.extend({
 
-  initialize: function(symbolJson){
+  initialize: function(symbolJson, options){
     this._symbolJson = symbolJson;
     this.val = null;
     this._styles = {};
     this._isDefault = false;
+    this._layerTransparency = 1;
+    if (options && options.layerTransparency) {
+      this._layerTransparency = 1 - (options.layerTransparency / 100.0);
+    }
   },
 
   //the geojson values returned are in points
@@ -18,7 +22,8 @@ EsriLeafletRenderers.Symbol = L.Class.extend({
   },
 
   alphaValue: function(color){
-    return color[3] / 255.0;
+    var alpha = color[3] / 255.0;
+    return alpha * this._layerTransparency;
   },
 
   getSize: function(feature, sizeInfo) {


### PR DESCRIPTION
This covers all but the picture symbol transparency. I tested on fill, line and esri marker symbols and it matched online rendering of the layer.