### PR TITLE
correct usage of geometry to layer

### DIFF
--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -77,7 +77,7 @@ L.esri.FeatureLayer.addInitHook(function () {
   };
 
   this.createNewLayer = function (geojson) {
-    var fLayer = L.GeoJSON.geometryToLayer(geojson, this.options.pointToLayer, L.GeoJSON.coordsToLatLng, this.options);
+    var fLayer = L.GeoJSON.geometryToLayer(geojson, this.options);
 
     // add a point layer when the polygon is represented as proportional marker symbols
     if (this._hasProportionalSymbols) {


### PR DESCRIPTION
More isn't always better, I had accepted the usage in master thinking the additional arguments were needed but the simplified one was intentional in 2.0.0