### PR TITLE
Style mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [Unreleased]
+
+### Added
+
+* Now developers can now override individual style properties of interest directly in the FeatureLayer constructor. (via #100)
+
+```js
+L.esri.featureLayer({
+  url: 'http://[server]/arcgis/rest/services/[yourservice]/MapServer/0',
+  style: function (feature) {
+    return {
+      // override service symbology to make polygon fill 50% transparent
+      fillOpacity: 0.5
+    };
+  }
+}).addTo(map);
+```
+
 ## [2.0.0] - 2015-09-10
 
 This is the first release that supports [Leaflet 1.0.0-beta.1](http://leafletjs.com/2015/07/15/leaflet-1.0-beta1-released.html).  As with version [1.0.0](https://github.com/Esri/esri-leaflet/releases/tag/v1.0.0) of Esri Leaflet, FeatureLayer constructors now expect `url`s to be provided within an options object (ie: `L.esri.featureLayer(url)` should be replaced with `L.esri.featureLayer( {url: url} )`).
@@ -42,6 +60,7 @@ This is expected to be the last (and only) stable release of Esri Leaflet Render
 * First Beta release
 * Works with esri-leaflet 1.0.0-rc.4
 
+[Unreleased]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/Esri/esri-leaflet-renderers/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/Esri/esri-leaflet-renderers/compare/v0.0.1-beta.3...v1.0.0
 [0.0.1-beta.3]: https://github.com/Esri/esri-leaflet-renderers/compare/v0.0.1-beta.2...v0.0.1-beta.3

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ You can also find a side by side comparison of the ArcGIS API for JavaScript [he
 1. [Fork and clone Esri Leaflet Renderers](https://help.github.com/articles/fork-a-repo)
 2. `cd` into the `esri-leaflet-renderers` folder
 3. Install the dependencies with `npm install`
-4. Run `npm run build` from the command line. This will compile minified source in a brand new `dist` directory.  Afterward, you can run `npm test` to make sure things are 'all good'.
+4. Run `npm run serve` from the command line. This will compile minified source in a brand new `dist` directory, launch a tiny webserver and begin watching the raw source for changes.
+5. Run `npm test` to make sure you haven't introduced a new 'feature' accidently.
 5. Make your changes and create a [pull request](https://help.github.com/articles/creating-a-pull-request)
 
 ### Limitations

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babelify": "^6.1.3",
     "chai": "2.3.0",
     "gh-release": "^2.0.0",
+    "http-server": "^0.8.5",
     "isparta": "^3.0.3",
     "istanbul": "gotwarlost/istanbul.git#source-map",
     "karma": "^0.12.24",
@@ -44,6 +45,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sourcemap-loader": "^0.3.5",
     "mkdirp": "^0.5.1",
+    "nodemon": "^1.7.2",
     "phantomjs": "^1.9.17",
     "rollup": "^0.10.0",
     "semistandard": "^6.1.2",
@@ -77,9 +79,10 @@
   "scripts": {
     "prepublish": "npm run build",
     "prebuild": "mkdirp dist",
-    "build": "./scripts/build.js",
+    "build": "node ./scripts/build.js",
     "lint": "semistandard src/**/*.js",
-    "release": "./scripts/release.sh",
+    "release": "node ./scripts/release.sh",
+    "serve": "nodemon --watch src --exec 'npm run build' & http-server -p 5678 -c-1 -o",
     "test": "npm run lint && npm run build && karma start"
   }
 }

--- a/spec/Renderers/ClassBreaksRendererSpec.js
+++ b/spec/Renderers/ClassBreaksRendererSpec.js
@@ -79,5 +79,20 @@ describe('ClassBreaksRenderer', function () {
       var sym = renderer._getSymbol(feature);
       expect(sym.val).to.be.eq(64615118);
     });
+
+    it('should merge symbol styles', function () {
+      var options = {
+        userDefinedStyle: function (feature) {
+          return {opacity: 0.5};
+        }
+      }
+      var renderer = L.esri.Renderers.classBreaksRenderer(rendererJson, options);
+      var feature = {'properties': {'SHAPE_AREA': 50000000}};
+      var style = renderer.style(feature);
+      // user style
+      expect(style.opacity).to.be.eq(0.5);
+      // renderer style
+      expect(style.weight).to.be.greaterThan(1);
+    });
   });
 });

--- a/spec/Renderers/SimpleRendererSpec.js
+++ b/spec/Renderers/SimpleRendererSpec.js
@@ -24,5 +24,20 @@ describe('SimpleRenderer', function () {
       var renderer = L.esri.Renderers.simpleRenderer(rendererJson);
       expect(renderer._symbols.length).to.be.eq(1);
     });
+
+
+    it('should merge symbol styles', function () {
+      var options = {
+        userDefinedStyle: function (feature) {
+          return {opacity: 0.5};
+        }
+      }
+      var renderer = L.esri.Renderers.simpleRenderer(rendererJson, options);
+      var style = renderer.style();
+      // user style
+      expect(style.opacity).to.be.eq(0.5);
+      // renderer style
+      expect(style.weight).to.be.lessThan(1);
+    });
   });
 });

--- a/spec/Renderers/UniqueValueRendererSpec.js
+++ b/spec/Renderers/UniqueValueRendererSpec.js
@@ -70,6 +70,21 @@ describe('UniqueValueRenderer', function () {
       expect(renderer._symbols.length).to.be.eq(3);
     });
 
+    it('should merge symbol styles', function () {
+      var options = {
+        userDefinedStyle: function (feature) {
+          return {opacity: 0.5};
+        }
+      }
+      var renderer = L.esri.Renderers.uniqueValueRenderer(rendererJson, options);
+      var feature = {'properties': {'ZONE': -12, 'VALUE': '$25.00', 'MARKET': '2Z'}};
+      var style = renderer.style(feature);
+      // user style
+      expect(style.opacity).to.be.eq(0.5);
+      // renderer style
+      expect(style.weight).to.be.greaterThan(1);
+    });
+
     describe('symbol transparency', function () {
       it('should be equal to symbol value when no layer transparency defined', function () {
         var renderer = L.esri.Renderers.uniqueValueRenderer(rendererJson);

--- a/spec/reset-style.html
+++ b/spec/reset-style.html
@@ -30,7 +30,12 @@
 
       L.esri.basemapLayer('Gray').addTo(map);
       var neighborhoods = L.esri.featureLayer({
-        url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0'
+        url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0',
+        style: function(feature) {
+          if (feature.properties.NAME === 'DOWNTOWN') {
+            return {fillColor: '#C00'};
+          }
+        }
       }).addTo(map);
 
       neighborhoods.on('mouseover', function(e){

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -15,7 +15,7 @@ L.esri.FeatureLayer.addInitHook(function () {
     if (error) {
       return;
     }
-    if (response && response.drawingInfo && !this.options.style) {
+    if (response && response.drawingInfo) {
       this._setRenderers(response);
     }
 
@@ -166,6 +166,9 @@ L.esri.FeatureLayer.addInitHook(function () {
 
     if (geojson.drawingInfo.transparency) {
       options.layerTransparency = geojson.drawingInfo.transparency;
+    }
+    if (this.options.style) {
+      options.userDefinedStyle = this.options.style;
     }
 
     switch (rendererInfo.type) {

--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -71,14 +71,38 @@ export var Renderer = L.Class.extend({
   },
 
   style: function (feature) {
+    var userStyles;
+    if (this.options.userDefinedStyle) {
+      userStyles = this.options.userDefinedStyle(feature);
+    }
     // find the symbol to represent this feature
     var sym = this._getSymbol(feature);
     if (sym) {
-      return sym.style(feature, this._visualVariables);
+      return this.mergeStyles(sym.style(feature, this._visualVariables), userStyles);
     } else {
       // invisible symbology
-      return {opacity: 0, fillOpacity: 0};
+      return this.mergeStyles({opacity: 0, fillOpacity: 0}, userStyles);
     }
+  },
+
+  mergeStyles: function (styles, userStyles) {
+    var mergedStyles = {};
+    var attr;
+    // copy renderer style attributes
+    for (attr in styles) {
+      if (styles.hasOwnProperty(attr)) {
+        mergedStyles[attr] = styles[attr];
+      }
+    }
+    // override with user defined style attributes
+    if (userStyles) {
+      for (attr in userStyles) {
+        if (userStyles.hasOwnProperty(attr)) {
+          mergedStyles[attr] = userStyles[attr];
+        }
+      }
+    }
+    return mergedStyles;
   }
 });
 


### PR DESCRIPTION
Attempt to resolve #53 

Sets styles from renderer definition and then overrides attributes that have values from the user's style function.

Does not work for Point layers.

Updated spec/reset-style.html to have a user defined style as well.