### PR TITLE
Don't call the bound onAdd in metadata, just in this onAdd

### DIFF
--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -18,20 +18,11 @@ L.esri.FeatureLayer.addInitHook(function () {
     if (response && response.drawingInfo) {
       this._setRenderers(response);
     }
-
-    this._metadataLoaded = true;
-    if (this._loadedMap) {
-      oldOnAdd(this._loadedMap);
-      this._addPointLayer(this._loadedMap);
-    }
   }, this);
 
   this.onAdd = function (map) {
-    this._loadedMap = map;
-    if (this._metadataLoaded) {
-      oldOnAdd(this._loadedMap);
-      this._addPointLayer(this._loadedMap);
-    }
+    oldOnAdd(map);
+    this._addPointLayer(map);
   };
 
   this.onRemove = function (map) {


### PR DESCRIPTION
@jgravois I pulled out all the logic around calling onAdd in metadata.

@patrickarlt I don't remember why we were allowing for calling the bound onAdd in metadata.  This change fixes the issue noted in #105 but I'd like you to take a quick look at the changes here.