### PR TITLE
Allowing the passing of layer options (e.g. pane, etc.) to the symbols 

### DIFF
--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -61,10 +61,10 @@ export var Renderer = L.Class.extend({
     }
   },
 
-  pointToLayer: function (geojson, latlng) {
+  pointToLayer: function (geojson, latlng, options) {
     var sym = this._getSymbol(geojson);
     if (sym && sym.pointToLayer) {
-      return sym.pointToLayer(geojson, latlng, this._visualVariables);
+      return sym.pointToLayer(geojson, latlng, this._visualVariables, options);
     }
     // invisible symbology
     return L.circleMarker(latlng, {radius: 0, opacity: 0});

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -102,7 +102,7 @@ export var PointSymbol = Symbol.extend({
     }
 
     if (this._symbolJson.type === 'esriPMS') {
-      layerOptions = L.extend({}, {icon: this._getIcon(size)}, options);
+      var layerOptions = L.extend({}, {icon: this._getIcon(size)}, options);
       return L.marker(latlng, layerOptions);
     }
     size = this.pixelValue(size);

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -3,11 +3,12 @@ import Symbol from './Symbol';
 import {squareMarker, xMarker, crossMarker, diamondMarker} from 'leaflet-shape-markers';
 
 export var PointSymbol = Symbol.extend({
+
   statics: {
     MARKERTYPES: ['esriSMSCircle', 'esriSMSCross', 'esriSMSDiamond', 'esriSMSSquare', 'esriSMSX', 'esriPMS']
   },
-  initialize: function (symbolJson, options) {
 
+  initialize: function (symbolJson, options) {
     Symbol.prototype.initialize.call(this, symbolJson, options);
     if (options) {
       this.serviceUrl = options.url;
@@ -83,7 +84,6 @@ export var PointSymbol = Symbol.extend({
   },
 
   pointToLayer: function (geojson, latlng, visualVariables, options) {
-
     var size = this._symbolJson.size || this._symbolJson.width;
     if (!this._isDefault) {
       if (visualVariables.sizeInfo) {

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -7,6 +7,7 @@ export var PointSymbol = Symbol.extend({
     MARKERTYPES: ['esriSMSCircle', 'esriSMSCross', 'esriSMSDiamond', 'esriSMSSquare', 'esriSMSX', 'esriPMS']
   },
   initialize: function (symbolJson, options) {
+
     Symbol.prototype.initialize.call(this, symbolJson, options);
     if (options) {
       this.serviceUrl = options.url;
@@ -81,7 +82,8 @@ export var PointSymbol = Symbol.extend({
     return icon;
   },
 
-  pointToLayer: function (geojson, latlng, visualVariables) {
+  pointToLayer: function (geojson, latlng, visualVariables, options) {
+
     var size = this._symbolJson.size || this._symbolJson.width;
     if (!this._isDefault) {
       if (visualVariables.sizeInfo) {
@@ -100,22 +102,23 @@ export var PointSymbol = Symbol.extend({
     }
 
     if (this._symbolJson.type === 'esriPMS') {
-      return L.marker(latlng, {icon: this._getIcon(size)});
+      layerOptions = L.extend({}, {icon: this._getIcon(size)}, options);
+      return L.marker(latlng, layerOptions);
     }
     size = this.pixelValue(size);
 
     switch (this._symbolJson.style) {
       case 'esriSMSSquare':
-        return squareMarker(latlng, size, this._styles);
+        return squareMarker(latlng, size, L.extend({}, this._styles, options));
       case 'esriSMSDiamond':
-        return diamondMarker(latlng, size, this._styles);
+        return diamondMarker(latlng, size, L.extend({}, this._styles, options));
       case 'esriSMSCross':
-        return crossMarker(latlng, size, this._styles);
+        return crossMarker(latlng, size, L.extend({}, this._styles, options));
       case 'esriSMSX':
-        return xMarker(latlng, size, this._styles);
+        return xMarker(latlng, size, L.extend({}, this._styles, options));
     }
     this._styles.radius = size / 2.0;
-    return L.circleMarker(latlng, this._styles);
+    return L.circleMarker(latlng, L.extend({}, this._styles, options));
   }
 });
 


### PR DESCRIPTION
Right now, esri-leaflet-renderers doesn't support adding the created Point features to a specific pane, and this prevents from managing the order of the layers.

Passing the layer options as an additional argument to the pointToLayer function solves the issue.
The intent is that `L.GeoJSON.geometryToLayer()` takes advantage of this feature to propagate the options passed. too.

Note: I wasn't able to fully test the different marker types.