### PR TITLE
ensure marker symbols are drawn in the appropriate pane

### DIFF
--- a/debug/sample.html
+++ b/debug/sample.html
@@ -32,7 +32,7 @@
       L.esri.basemapLayer('Streets').addTo(map);
 
       // draw the predefined Portland Heritage Tree symbols
-      // L.esri.featureLayer({url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'}).addTo(map);
+      L.esri.featureLayer({url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'}).addTo(map);
     </script>
 
   </body>

--- a/spec/Markers/CrossMarkerSpec.js
+++ b/spec/Markers/CrossMarkerSpec.js
@@ -5,7 +5,6 @@ describe('CrossMarker', function () {
     beforeEach(function () {
       map = L.map(document.createElement('div'));
       map.setView([0, 0], 1);
-      map.createPane('custom');
     });
     describe('when a CrossMarker is added to the map ', function () {
 
@@ -51,16 +50,6 @@ describe('CrossMarker', function () {
           marker.setLatLng(L.latLng(44, -128));
           expect(marker.getLatLng().lat).to.eq(44);
           expect(marker.getLatLng().lng).to.eq(-128);
-        });
-      });
-
-      describe('and pass through custom panes', function () {
-        it('if they are specified in the constructor', function () {
-          var marker = L.shapeMarkers.crossMarker([0, 0], 20, {
-            pane: 'custom'
-          });
-          marker.addTo(map);
-          expect(map.getPane('custom').childElementCount).to.eq(1);
         });
       });
 

--- a/spec/Markers/DiamondMarkerSpec.js
+++ b/spec/Markers/DiamondMarkerSpec.js
@@ -5,7 +5,6 @@ describe('DiamondMarker', function () {
     beforeEach(function () {
       map = L.map(document.createElement('div'));
       map.setView([0, 0], 1);
-      map.createPane('custom');
     });
     describe('when a DiamondMarker is added to the map ', function () {
       it('should have center and size set', function () {
@@ -50,16 +49,6 @@ describe('DiamondMarker', function () {
           marker.setLatLng(L.latLng(44, -128));
           expect(marker.getLatLng().lat).to.eq(44);
           expect(marker.getLatLng().lng).to.eq(-128);
-        });
-      });
-
-      describe('and pass through custom panes', function () {
-        it('if they are specified in the constructor', function () {
-          var marker = L.shapeMarkers.diamondMarker([0, 0], 20, {
-            pane: 'custom'
-          });
-          marker.addTo(map);
-          expect(map.getPane('custom').childElementCount).to.eq(1);
         });
       });
     });

--- a/spec/Markers/SquareMarkerSpec.js
+++ b/spec/Markers/SquareMarkerSpec.js
@@ -5,7 +5,6 @@ describe('SquareMarker', function () {
     beforeEach(function () {
       map = L.map(document.createElement('div'));
       map.setView([0, 0], 1);
-      map.createPane('custom');
     });
     describe('when a SquareMarker is added to the map ', function () {
       it('should have center and size set', function () {
@@ -50,16 +49,6 @@ describe('SquareMarker', function () {
           marker.setLatLng(L.latLng(44, -128));
           expect(marker.getLatLng().lat).to.eq(44);
           expect(marker.getLatLng().lng).to.eq(-128);
-        });
-      });
-
-      describe('and pass through custom panes', function () {
-        it('if they are specified in the constructor', function () {
-          var marker = L.shapeMarkers.squareMarker([0, 0], 20, {
-            pane: 'custom'
-          });
-          marker.addTo(map);
-          expect(map.getPane('custom').childElementCount).to.eq(1);
         });
       });
     });

--- a/spec/Markers/XMarkerSpec.js
+++ b/spec/Markers/XMarkerSpec.js
@@ -52,16 +52,6 @@ describe('XMarker', function () {
           expect(marker.getLatLng().lng).to.eq(-128);
         });
       });
-
-      describe('and pass through custom panes', function () {
-        it('if they are specified in the constructor', function () {
-          var marker = L.shapeMarkers.xMarker([0, 0], 20, {
-            pane: 'custom'
-          });
-          marker.addTo(map);
-          expect(map.getPane('custom').childElementCount).to.eq(1);
-        });
-      });
     });
   });
 });

--- a/spec/Renderers/SimpleRendererSpec.js
+++ b/spec/Renderers/SimpleRendererSpec.js
@@ -25,7 +25,6 @@ describe('SimpleRenderer', function () {
       expect(renderer._symbols.length).to.be.eq(1);
     });
 
-
     it('should merge symbol styles', function () {
       var options = {
         userDefinedStyle: function (feature) {

--- a/spec/comparisons.html
+++ b/spec/comparisons.html
@@ -35,7 +35,7 @@
 
     <script>
       var layers = [{
-        url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0',
+        url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Neighborhoods_pdx/FeatureServer/0',
         title: 'Portland Neighborhoods',
         geoType: 'Polygon',
         rendererType: 'Classbreaks',
@@ -43,7 +43,7 @@
         lon: -122.653,
         zoomLevel: 11
       }, {
-        url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Freeway_System/FeatureServer/1',
+        url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Freeway_System/FeatureServer/1',
         title: 'Freeways',
         geoType: 'Line',
         rendererType: 'Simple',
@@ -51,7 +51,7 @@
         lon: -81.7,
         zoomLevel: 6
       }, {
-        url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_States_Generalized/FeatureServer/0',
+        url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_States_Generalized/FeatureServer/0',
         title: 'USA States (Generalized)',
         geoType: 'Polygon',
         rendererType: 'Simple',
@@ -59,7 +59,7 @@
         lon: -119,
         zoomLevel: 3
       }, {
-        url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Time_Zones/FeatureServer/0',
+        url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Time_Zones/FeatureServer/0',
         title: 'Timezones',
         geoType: 'Polygon',
         rendererType: 'Unique Value',
@@ -67,7 +67,7 @@
         lon: 74.9,
         zoomLevel: 3
       }, {
-        url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/minop3x020_nt00020/FeatureServer/0',
+        url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/minop3x020_nt00020/FeatureServer/0',
         title: 'Esri Marker Symbols Test',
         geoType: 'Point',
         rendererType: 'Unique Value',
@@ -75,7 +75,7 @@
         lon: -97,
         zoomLevel: 4
       }, {
-        url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Regions/FeatureServer/0',
+        url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Regions/FeatureServer/0',
         title: 'World Regions',
         geoType: 'Polygon',
         rendererType: 'Unique Value',

--- a/spec/custom-pane.html
+++ b/spec/custom-pane.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=utf-8 />
+    <title>Simple FeatureLayer</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+    <!-- Load Leaflet from CDN-->
+    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+    <script src="../node_modules/leaflet/dist/leaflet-src.js"></script>
+
+    <!-- Load Esri Leaflet -->
+    <script src="../node_modules/esri-leaflet/dist/esri-leaflet-debug.js"></script>
+
+    <!-- Load compiled Esri Leaflet Renderers -->
+    <script src="../dist/esri-leaflet-renderers-debug.js"></script>
+
+    <style>
+      body {margin:0;padding:0;}
+      #mapD {position: absolute;top:0;bottom:0;right:0;left:0;}
+    </style>
+  </head>
+  <body>
+
+    <div id="mapD"></div>
+
+    <script>
+      var map = L.map('mapD').setView([41.79831962736954, -88.216266], 16);
+      L.esri.basemapLayer('Streets').addTo(map);
+      map.createPane('custom');
+
+      // // picture marker symbol
+      // L.esri.featureLayer({
+      //   url: 'http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Louisville/LOJIC_PublicSafety_Louisville/MapServer/1',
+      //   pane: 'custom',
+      //   useCors: false
+      // }).addTo(map);
+      //
+      // // circle marker symbol
+      // L.esri.featureLayer({
+      //   url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/0',
+      //   pane: 'custom',
+      //   useCors: false
+      // }).addTo(map);
+
+      // misc marker symbols
+      L.esri.featureLayer({
+        url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/CommunityAddressing/MapServer/0'// ,
+        // pane: 'custom'
+      }).addTo(map);
+
+      // once layers have loaded, inspect DOM and make sure nothing is present in the default marker or overlay panes
+    </script>
+
+  </body>
+</html>

--- a/spec/custom-pane.html
+++ b/spec/custom-pane.html
@@ -25,28 +25,22 @@
     <div id="mapD"></div>
 
     <script>
-      var map = L.map('mapD').setView([41.79831962736954, -88.216266], 16);
+      var map = L.map('mapD').setView([38.25482978059097, -85.76378345489502], 15);
       L.esri.basemapLayer('Streets').addTo(map);
       map.createPane('custom');
 
-      // // picture marker symbol
-      // L.esri.featureLayer({
-      //   url: 'http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Louisville/LOJIC_PublicSafety_Louisville/MapServer/1',
-      //   pane: 'custom',
-      //   useCors: false
-      // }).addTo(map);
-      //
-      // // circle marker symbol
-      // L.esri.featureLayer({
-      //   url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/0',
-      //   pane: 'custom',
-      //   useCors: false
-      // }).addTo(map);
-
-      // misc marker symbols
+      // picture marker symbol
       L.esri.featureLayer({
-        url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/CommunityAddressing/MapServer/0'// ,
-        // pane: 'custom'
+        url: 'http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Louisville/LOJIC_PublicSafety_Louisville/MapServer/1',
+        pane: 'custom',
+        useCors: false
+      }).addTo(map);
+
+      // circle marker symbol
+      L.esri.featureLayer({
+        url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/0',
+        pane: 'custom',
+        useCors: false
       }).addTo(map);
 
       // once layers have loaded, inspect DOM and make sure nothing is present in the default marker or overlay panes

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -160,13 +160,17 @@ L.esri.FeatureLayer.addInitHook(function () {
   this._setRenderers = function (geojson) {
     var rend;
     var rendererInfo = geojson.drawingInfo.renderer;
+
     var options = {
       url: this.options.url
     };
+
     if (this.options.token) {
       options.token = this.options.token;
     }
-
+    if (this.options.pane) {
+      options.pane = this.options.pane;
+    }
     if (geojson.drawingInfo.transparency) {
       options.layerTransparency = geojson.drawingInfo.transparency;
     }

--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -61,9 +61,10 @@ export var Renderer = L.Class.extend({
     }
   },
 
-  pointToLayer: function (geojson, latlng, options) {
+  pointToLayer: function (geojson, latlng) {
     var sym = this._getSymbol(geojson);
     if (sym && sym.pointToLayer) {
+      // right now custom panes are the only option pushed through
       return sym.pointToLayer(geojson, latlng, this._visualVariables, this.options);
     }
     // invisible symbology

--- a/src/Renderers/Renderer.js
+++ b/src/Renderers/Renderer.js
@@ -64,7 +64,7 @@ export var Renderer = L.Class.extend({
   pointToLayer: function (geojson, latlng, options) {
     var sym = this._getSymbol(geojson);
     if (sym && sym.pointToLayer) {
-      return sym.pointToLayer(geojson, latlng, this._visualVariables, options);
+      return sym.pointToLayer(geojson, latlng, this._visualVariables, this.options);
     }
     // invisible symbology
     return L.circleMarker(latlng, {radius: 0, opacity: 0});


### PR DESCRIPTION
@pbastia can you provide a little clarification about what client side developers need to do to benefit from your changes in #112 when you have a moment?

i haven't had success using the approach below (testing against leaflet `1.0.0-rc.1`).
```js
map.createPane('custom');

// circle marker symbol
L.esri.featureLayer({
  url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/0',
  pane: 'custom'
}).addTo(map);

/* 
also tried picture marker symbols
https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet%20Transit%20Stops%20In%20Portland%20Neighborhoods/FeatureServer/0

and this layer which includes diamond markers, among others...
http://sampleserver6.arcgisonline.com/arcgis/rest/services/Military/MapServer/3
*/
```