### PR TITLE
set style manually when metadata is slow

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "release": "./scripts/release.sh",
-    "start": "watch 'npm run build' & http-server -p 5000 -c-1 -o",
+    "start": "watch 'npm run build' src & http-server -p 5000 -c-1 -o",
     "test": "npm run lint && npm run build && karma start"
   }
 }

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -1,5 +1,4 @@
  import L from 'leaflet';
-// import { FeatureLayer } from 'esri-leaflet';
 
 import classBreaksRenderer from './Renderers/ClassBreaksRenderer';
 import uniqueValueRenderer from './Renderers/UniqueValueRenderer';
@@ -22,19 +21,16 @@ L.esri.FeatureLayer.addInitHook(function () {
       this._setRenderers(response);
     }
 
-    this._metadataLoaded = true;
-    if (this._loadedMap) {
-      oldOnAdd(this._loadedMap);
-      this._addPointLayer(this._loadedMap);
+    if (this._alreadyAdded) {
+      this.setStyle(this._originalStyle);
     }
   }, this);
 
   this.onAdd = function (map) {
     this._loadedMap = map;
-    if (this._metadataLoaded) {
-      oldOnAdd(this._loadedMap);
-      this._addPointLayer(this._loadedMap);
-    }
+    oldOnAdd(this._loadedMap);
+    this._addPointLayer(this._loadedMap);
+    this._alreadyAdded = true;
   };
 
   this.onRemove = function (map) {

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -16,20 +16,16 @@ L.esri.FeatureLayer.addInitHook(function () {
   this.metadata(function (error, response) {
     if (error) {
       return;
-    }
-    if (response && response.drawingInfo) {
+    } if (response && response.drawingInfo) {
       this._setRenderers(response);
-    }
-
-    if (this._alreadyAdded) {
+    } if (this._alreadyAdded) {
       this.setStyle(this._originalStyle);
     }
   }, this);
 
   this.onAdd = function (map) {
-    this._loadedMap = map;
-    oldOnAdd(this._loadedMap);
-    this._addPointLayer(this._loadedMap);
+    oldOnAdd(map);
+    this._addPointLayer(map);
     this._alreadyAdded = true;
   };
 


### PR DESCRIPTION
resolves #105 

i'm not terribly fond of it, but this fix avoids the race condition and ensures that the appropriate symbology is always utilized by setting styles manually *after* features have already drawn in the rare situation that the metadata response is slower than the initial wave of queries.

* in typical situations, everything should draw perfectly and no errors should appear in the console when loading the repro case the user provided.
* if you add a timeout back into `L.esri.Service.metadata`, you'll see the features draw initially in the default blue, then refresh once the metadata is retrieved.

@kneemer, hope you're well. if you can spare the time to give this PR a quick review, i'd *really* appreciate it.