### PR TITLE
Rewriting a drawingInfo from the service with an original one.

### DIFF
--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -180,20 +180,19 @@ L.esri.FeatureLayer.addInitHook(function () {
     rend.attachStylesToLayer(this);
   };
 
-    this.metadata(function (error, response) {
-        if (error) {
-            return;
-        } if (response && response.drawingInfo) {
-            if(this.options.drawingInfo) {
-                var originalMetadata = response;
-                originalMetadata.drawingInfo = this.options.drawingInfo;
-                this._setRenderers(originalMetadata);
-            }
-            else {
-                this._setRenderers(response);
-            }
-        } if (this._alreadyAdded) {
-            this.setStyle(this._originalStyle);
-        }
-    }, this);
+  this.metadata(function (error, response) {
+    if (error) {
+      return;
+    } if (response && response.drawingInfo) {
+      if (this.options.drawingInfo) {
+        var originalMetadata = response;
+        originalMetadata.drawingInfo = this.options.drawingInfo;
+        this._setRenderers(originalMetadata);
+      } else {
+        this._setRenderers(response);
+      }
+    } if (this._alreadyAdded) {
+      this.setStyle(this._originalStyle);
+    }
+  }, this);
 });

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -184,13 +184,11 @@ L.esri.FeatureLayer.addInitHook(function () {
     if (error) {
       return;
     } if (response && response.drawingInfo) {
+      // if drawingInfo from a webmap is supplied in the layer constructor, use that instead
       if (this.options.drawingInfo) {
-        var originalMetadata = response;
-        originalMetadata.drawingInfo = this.options.drawingInfo;
-        this._setRenderers(originalMetadata);
-      } else {
-        this._setRenderers(response);
+        response.drawingInfo = this.options.drawingInfo;
       }
+      this._setRenderers(response);
     } if (this._alreadyAdded) {
       this.setStyle(this._originalStyle);
     }

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -13,16 +13,6 @@ L.esri.FeatureLayer.addInitHook(function () {
   var oldOnRemove = L.Util.bind(this.onRemove, this);
   L.Util.bind(this.createNewLayer, this);
 
-  this.metadata(function (error, response) {
-    if (error) {
-      return;
-    } if (response && response.drawingInfo) {
-      this._setRenderers(response);
-    } if (this._alreadyAdded) {
-      this.setStyle(this._originalStyle);
-    }
-  }, this);
-
   this.onAdd = function (map) {
     oldOnAdd(map);
     this._addPointLayer(map);
@@ -189,4 +179,21 @@ L.esri.FeatureLayer.addInitHook(function () {
     }
     rend.attachStylesToLayer(this);
   };
+
+    this.metadata(function (error, response) {
+        if (error) {
+            return;
+        } if (response && response.drawingInfo) {
+            if(this.options.drawingInfo) {
+                var originalMetadata = response;
+                originalMetadata.drawingInfo = this.options.drawingInfo;
+                this._setRenderers(originalMetadata);
+            }
+            else {
+                this._setRenderers(response);
+            }
+        } if (this._alreadyAdded) {
+            this.setStyle(this._originalStyle);
+        }
+    }, this);
 });

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -17,8 +17,8 @@ export var PointSymbol = Symbol.extend({
       if (symbolJson.type === 'esriPMS') {
         var url = this.serviceUrl + 'images/' + this._symbolJson.url;
         this._iconUrl = options && options.token ? url + '?token=' + options.token : url;
-        if(symbolJson.imageData) {
-            this._iconUrl = 'data:' + symbolJson.contentType + ';base64,' + symbolJson.imageData;
+        if (symbolJson.imageData) {
+          this._iconUrl = 'data:' + symbolJson.contentType + ';base64,' + symbolJson.imageData;
         }
         // leaflet does not allow resizing icons so keep a hash of different
         // icon sizes to try and keep down on the number of icons created

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -17,6 +17,9 @@ export var PointSymbol = Symbol.extend({
       if (symbolJson.type === 'esriPMS') {
         var url = this.serviceUrl + 'images/' + this._symbolJson.url;
         this._iconUrl = options && options.token ? url + '?token=' + options.token : url;
+        if(symbolJson.imageData) {
+            this._iconUrl = 'data:' + symbolJson.contentType + ';base64,' + symbolJson.imageData;
+        }
         // leaflet does not allow resizing icons so keep a hash of different
         // icon sizes to try and keep down on the number of icons created
         this._icons = {};


### PR DESCRIPTION
This PR is updating:
* rewriting drawingInfo from the service
* base64 images supported

I have tested to perform `L.esri.FeatureLayer.drawingInfo` in `L.esri.WebMap` and it is OK.
By this PR, it will be able to render feature layers using `drawingInfo` in Webmap JSON.

ynunokawa/L.esri.WebMap/issues/34