### PR TITLE
just wait for metadata response to load layer

### DIFF
--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -1,4 +1,4 @@
- import L from 'leaflet';
+import L from 'leaflet';
 
 import classBreaksRenderer from './Renderers/ClassBreaksRenderer';
 import uniqueValueRenderer from './Renderers/UniqueValueRenderer';
@@ -13,20 +13,17 @@ L.esri.FeatureLayer.addInitHook(function () {
   var oldOnRemove = L.Util.bind(this.onRemove, this);
   L.Util.bind(this.createNewLayer, this);
 
-  this.metadata(function (error, response) {
-    if (error) {
-      return;
-    } if (response && response.drawingInfo) {
-      this._setRenderers(response);
-    } if (this._alreadyAdded) {
-      this.setStyle(this._originalStyle);
-    }
-  }, this);
-
   this.onAdd = function (map) {
-    oldOnAdd(map);
-    this._addPointLayer(map);
-    this._alreadyAdded = true;
+    this.metadata(function (error, response) {
+      if (error) {
+        console.warn('failed to load metadata from the service.');
+        return
+      } if (response && response.drawingInfo) {
+        this._setRenderers(response);
+        oldOnAdd(map);
+        this._addPointLayer(map);
+      }
+    }, this);
   };
 
   this.onRemove = function (map) {


### PR DESCRIPTION
over the last couple days i've seen fairly reproducible sporadic flaky behavior when loading featureLayers with point geometries (because its not *that* uncommon for an individual query response to outrun the metadata request for symbology).  the problem is that some/all individual features are drawn with a default marker and fail to refresh once the metadata has finally been retrieved.  it is caused by the fact that the `setStyle()` call i jammed in previously only redraws paths (w/ a style).

i took a stab at overwriting default point markers with the newly hydrated pointToLayer() method, but since the function can return an icon (or `L.circleMarker`, or one of our shapeMarkers), it'd be a *whole lot simpler* to just do **one thing at a time**.