### PR TITLE
remove unnecessary codes

### DIFF
--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -17,15 +17,11 @@ L.esri.FeatureLayer.addInitHook(function () {
     this.metadata(function (error, response) {
       if (error) {
         console.warn('failed to load metadata from the service.');
-        return
+        return;
       } if (response && response.drawingInfo) {
-        if(this.options.drawingInfo) {
+        if (this.options.drawingInfo) {
           // allow L.esri.webmap (and others) to override service symbology with info provided in layer constructor
-          var serviceMetadata = response;
-          serviceMetadata.drawingInfo = this.options.drawingInfo;
-          this._setRenderers(serviceMetadata);
-        } else {
-          this._setRenderers(response);
+          response.drawingInfo = this.options.drawingInfo;
         }
         this._setRenderers(response);
         oldOnAdd(map);


### PR DESCRIPTION
there was an undesirable case to run `this._setRenderers` twice with
different arguments.

And it disabled [my demo app](http://ynunokawa.github.io/L.esri.WebMap/index.html) of `L.esri.WebMap` for pan control.
