### PR TITLE
Enable ArcGIS webmap point symbology via arbitrary URL

### DIFF
--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -17,12 +17,11 @@ export var PointSymbol = Symbol.extend({
     if (symbolJson) {
       if (symbolJson.type === 'esriPMS') {
         var imageUrl = this._symbolJson.url;
-        if (imageUrl && imageUrl.substr(0,7) === 'http://' || imageUrl.substr(0,8) === 'https://'){
+        if (imageUrl && imageUrl.substr(0, 7) === 'http://' || imageUrl.substr(0, 8) === 'https://') {
           // web image
           url = this.sanitize(imageUrl);
           this._iconUrl = url;
-        }
-        else {
+        } else {
           url = this.serviceUrl + 'images/' + imageUrl;
           this._iconUrl = options && options.token ? url + '?token=' + options.token : url;
         }
@@ -41,19 +40,18 @@ export var PointSymbol = Symbol.extend({
   },
 
   // prevent html injection in strings
-  sanitize: function(str) {
+  sanitize: function (str) {
     if (!str) {
       return '';
     }
     var text;
     try {
       // removes html but leaves url link text
-      text = str.replace(/<br>/gi, "\n");
-      text = text.replace(/<p.*>/gi, "\n");
-      text = text.replace(/<a.*href="(.*?)".*>(.*?)<\/a>/gi, " $2 ($1) ");
-      text = text.replace(/<(?:.|\s)*?>/g, "");
-    }
-    catch (ex) {
+      text = str.replace(/<br>/gi, '\n');
+      text = text.replace(/<p.*>/gi, '\n');
+      text = text.replace(/<a.*href='(.*?)'.*>(.*?)<\/a>/gi, ' $2 ($1) ');
+      text = text.replace(/<(?:.|\s)*?>/g, '');
+    } catch (ex) {
       text = null;
     }
     return text;


### PR DESCRIPTION
The current version only allows the rendering of point symbol URLs relative to the ArcGIS server.  One problem with this is licensing issues storing the images on the ArcGIS server.  Instead, storing only the URL of the image keeps the image under the control (and responsibility) of the user.

This change will render images located anywhere on the web.  For instance, the user can to go into ArcGIS.com map viewer and change point symbols to their own image urls in Dropbox, Google Drive, etc.

For instance, the user can go into ArcGIS map viewer and change point symbology:
<img width="473" alt="choosingmarkerimage" src="https://cloud.githubusercontent.com/assets/4062792/17597346/34afe27e-5faa-11e6-8893-57fa2bab3eea.png">

The image being set here is from a public imgur.com link:  http://i.imgur.com/vcGiTA2.png

This change will then allow the renders to show the same point symbol that ArcGIS shows in that case.  Here is the webmap displayed using L.esri.WebMap plugin:

<img width="257" alt="webmarkers" src="https://cloud.githubusercontent.com/assets/4062792/17596916/68f7204e-5fa8-11e6-9968-800f2cebe006.png">

**NOTE**:  this change includes a small function named 'sanitize()' that takes the user's URL and makes sure is does not contain html (prevent injection).  There may be a better place to put that function since it may be useful in other code. 