### PR TITLE
dont ask for layer metadata twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "John Gravois <jgravois@esri.com>"
   ],
   "dependencies": {
-     "esri-leaflet": "^2.0.0-beta.8",
-     "leaflet": "^1.0.0-beta.2",
+     "esri-leaflet": "^2.0.0",
+     "leaflet": "^1.0.0-rc.3",
      "leaflet-shape-markers": "^1.0.4"
   },
   "devDependencies": {

--- a/src/FeatureLayerHook.js
+++ b/src/FeatureLayerHook.js
@@ -190,18 +190,4 @@ L.esri.FeatureLayer.addInitHook(function () {
     }
     rend.attachStylesToLayer(this);
   };
-
-  this.metadata(function (error, response) {
-    if (error) {
-      return;
-    } if (response && response.drawingInfo) {
-      // if drawingInfo from a webmap is supplied in the layer constructor, use that instead
-      if (this.options.drawingInfo) {
-        response.drawingInfo = this.options.drawingInfo;
-      }
-      this._setRenderers(response);
-    } if (this._alreadyAdded) {
-      this.setStyle(this._originalStyle);
-    }
-  }, this);
 });


### PR DESCRIPTION
my guess is that i accidentally introduced a duplicate call to `this.metadata` when merging #121 (because my own branch was stale)

removing it didn't in and of itself speed up layer drawing for me, but once i bumped the package.json dependencies, things got substantially snappier.

cc @ynunokawa 