### PR TITLE
add the case of 'esriSLSNull' style for outline

### DIFF
--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -32,7 +32,7 @@ export var PointSymbol = Symbol.extend({
   },
 
   _fillStyles: function () {
-    if (this._symbolJson.outline && this._symbolJson.size > 0) {
+    if (this._symbolJson.outline && this._symbolJson.size > 0 && this._symbolJson.outline.style !== 'esriSLSNull') {
       this._styles.stroke = true;
       this._styles.weight = this.pixelValue(this._symbolJson.outline.width);
       this._styles.color = this.colorValue(this._symbolJson.outline.color);

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -9,7 +9,9 @@ export var PolygonSymbol = Symbol.extend({
   initialize: function (symbolJson, options) {
     Symbol.prototype.initialize.call(this, symbolJson, options);
     if (symbolJson) {
-      this._lineStyles = lineSymbol(symbolJson.outline, options).style();
+      if (symbolJson.outline.style !== 'esriSLSNull') {
+        this._lineStyles = lineSymbol(symbolJson.outline, options).style();
+      }
       this._fillStyles();
     }
   },
@@ -26,6 +28,8 @@ export var PolygonSymbol = Symbol.extend({
           this._styles[styleAttr] = this._lineStyles[styleAttr];
         }
       }
+    } else {
+      this._styles.stroke = false;
     }
 
     // set the fill for the polygon

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -9,7 +9,8 @@ export var PolygonSymbol = Symbol.extend({
   initialize: function (symbolJson, options) {
     Symbol.prototype.initialize.call(this, symbolJson, options);
     if (symbolJson) {
-      if (symbolJson.outline.style !== 'esriSLSNull') {
+        this._lineStyles = { weight: 0 };
+      } else {
         this._lineStyles = lineSymbol(symbolJson.outline, options).style();
       }
       this._fillStyles();
@@ -28,8 +29,6 @@ export var PolygonSymbol = Symbol.extend({
           this._styles[styleAttr] = this._lineStyles[styleAttr];
         }
       }
-    } else {
-      this._styles.stroke = false;
     }
 
     // set the fill for the polygon

--- a/src/Symbols/PolygonSymbol.js
+++ b/src/Symbols/PolygonSymbol.js
@@ -9,6 +9,7 @@ export var PolygonSymbol = Symbol.extend({
   initialize: function (symbolJson, options) {
     Symbol.prototype.initialize.call(this, symbolJson, options);
     if (symbolJson) {
+      if (symbolJson.outline && symbolJson.outline.style === 'esriSLSNull') {
         this._lineStyles = { weight: 0 };
       } else {
         this._lineStyles = lineSymbol(symbolJson.outline, options).style();


### PR DESCRIPTION
`esri-leaflet-renderers` does not draw features as expected as the below if an outline style of PointSymbol and PolygonSymbol is `'esriSLSNull'`.

- **PointSymbol**: 
It show an error message as `Symbol.js:22 Uncaught TypeError: Cannot read property '0' of null` and draw features with a leaflet default symbol (see https://jsfiddle.net/ynunokawa/0vpb8a9c/).

- **PolygonSymbol**: 
It draw features with a leaflet default symbol.

This PR will fix them!