### PR TITLE
2.0.5 release prep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.12"
+  - "7"
 cache:
   directories:
     - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+## [2.0.5] - 2017-06-01
+
+### Added
+* support for loading via AMD
+* support for Node 7
+
+### Fixed
+* ensure that point geometry layers are assigned to Leaflet's `markerPane` by default
+
 ## [2.0.4] - 2016-08-17
 
 ### Added
@@ -140,7 +149,8 @@ This is expected to be the last (and only) stable release of Esri Leaflet Render
 * First Beta release
 * Works with esri-leaflet 1.0.0-rc.4
 
-[Unreleased]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.4...HEAD
+[Unreleased]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.5...HEAD
+[2.0.5]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Esri/esri-leaflet-renderers/compare/v2.0.1...v2.0.2

--- a/package.json
+++ b/package.json
@@ -11,35 +11,36 @@
     "John Gravois <jgravois@esri.com>"
   ],
   "dependencies": {
-     "esri-leaflet": "^2.0.0",
-     "leaflet": "^1.0.0-rc.3",
-     "leaflet-shape-markers": "^1.0.4"
+    "esri-leaflet": "^2.0.0",
+    "leaflet": "^1.0.0-rc.3",
+    "leaflet-shape-markers": "^1.0.4"
   },
   "devDependencies": {
     "babelify": "^6.1.3",
-    "chai": "2.3.0",
+    "chai": "3.5.0",
     "gh-release": "^2.0.0",
     "http-server": "^0.8.5",
-    "isparta": "^3.0.3",
+    "isparta": "^4.0.0",
     "istanbul": "^0.4.2",
-    "karma": "^0.12.24",
+    "karma": "^1.3.0",
     "karma-chai-sinon": "^0.1.3",
-    "karma-coverage": "^0.5.3",
-    "karma-mocha": "^0.1.0",
-    "karma-mocha-reporter": "^0.2.5",
-    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-coverage": "^1.1.1",
+    "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-sourcemap-loader": "^0.3.5",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.3.4",
-    "phantomjs": "^1.9.17",
+    "mocha": "^3.1.0",
+    "phantomjs-prebuilt": "^2.0.0",
     "rollup": "^0.25.4",
     "rollup-plugin-json": "^2.0.0",
     "rollup-plugin-node-resolve": "^1.4.0",
-    "rollup-plugin-uglify": "^0.2.0",
-    "semistandard": "^7.0.5",
+    "rollup-plugin-uglify": "^0.3.1",
+    "semistandard": "^10.0.0",
     "sinon": "^1.11.1",
-    "sinon-chai": "2.7.0",
-    "uglify-js": "^2.4.23",
+    "sinon-chai": "2.8.0",
+    "snazzy": "^5.0.0",
+    "uglify-js": "^2.6.1",
     "watch": "^0.17.1"
   },
   "homepage": "http://esri.github.io/esri-leaflet",
@@ -61,6 +62,7 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/esri-leaflet-renderers-debug.js",
+  "module": "src/EsriLeafletRenderers.js",
   "browser": "dist/esri-leaflet-renderers-debug.js",
   "readmeFilename": "README.md",
   "repository": {
@@ -70,11 +72,11 @@
   "scripts": {
     "prebuild": "mkdirp dist",
     "build": "rollup -c profiles/debug.js & rollup -c profiles/production.js",
-    "lint": "semistandard src/**/*.js",
+    "lint": "semistandard src/**/*.js | snazzy",
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "release": "./scripts/release.sh",
     "start": "watch 'npm run build' src & http-server -p 5000 -c-1 -o",
-    "test": "npm run lint && npm run build && karma start"
+    "test": "npm run lint && karma start"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-leaflet-renderers",
   "description": "esri-leaflet plugin for rendering",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "Rachel Nehmer <rnehmer@esri.com>",
   "bugs": {
     "url": "https://github.com/esri/esri-leaflet-renderers/issues"

--- a/src/Symbols/PointSymbol.js
+++ b/src/Symbols/PointSymbol.js
@@ -17,7 +17,7 @@ export var PointSymbol = Symbol.extend({
     if (symbolJson) {
       if (symbolJson.type === 'esriPMS') {
         var imageUrl = this._symbolJson.url;
-        if (imageUrl && imageUrl.substr(0, 7) === 'http://' || imageUrl.substr(0, 8) === 'https://') {
+        if ((imageUrl && imageUrl.substr(0, 7) === 'http://') || (imageUrl.substr(0, 8) === 'https://')) {
           // web image
           url = this.sanitize(imageUrl);
           this._iconUrl = url;

--- a/src/Symbols/Symbol.js
+++ b/src/Symbols/Symbol.js
@@ -121,7 +121,7 @@ export var Symbol = L.Class.extend({
             // weights to each of the rgba colors and adding them together
             var interpolatedColor = [];
             for (var j = 0; j < 4; j++) {
-              interpolatedColor[j] = Math.round(lowerBoundColor[j] * lowerBoundColorWeight + upperBoundColor[j] * upperBoundColorWeight);
+              interpolatedColor[j] = (Math.round(lowerBoundColor[j] * lowerBoundColorWeight) + (upperBoundColor[j] * upperBoundColorWeight));
             }
             return interpolatedColor;
           } else {


### PR DESCRIPTION
resolves #136 

* bumped dev dependencies so that tests can be run on Node v7
* linting (to please semistandard 10.0)
