### PR TITLE
upgrade package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2365,9 +2365,9 @@
       }
     },
     "esri-leaflet-cluster": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esri-leaflet-cluster/-/esri-leaflet-cluster-2.0.1.tgz",
-      "integrity": "sha512-xM2EAecHAQ5vxLg0YdxWXD9XIWHbmpQTSLPqfb76cf65mCcpQASeHo3jKxr1Pc7FCPCxSN197wec1wvbbrsSCQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/esri-leaflet-cluster/-/esri-leaflet-cluster-2.1.0.tgz",
+      "integrity": "sha512-q07BHPXkluyb8STt/2m2spSecBiZj/Eqaiab8J14mlJ9RxAF11HthDb/09UOiJTmbpgvLUV1nPs2l7dKyY7xqg==",
       "optional": true,
       "requires": {
         "esri-leaflet": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "leaflet-shape-markers": "1.x"
   },
   "optionalDependencies": {
-    "esri-leaflet-cluster": "^2.0.0"
+    "esri-leaflet-cluster": "^2.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^4.0.3",


### PR DESCRIPTION
Since there has been some changes in https://github.com/Esri/esri-leaflet-cluster/pull/31 that involves esri-leaflet-cluster 2.1.0 shouldn't it be upgraded ?