### PR TITLE
Bugfix/webpack5 errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -447,9 +447,9 @@
       "dev": true
     },
     "@terraformer/arcgis": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.0.7.tgz",
-      "integrity": "sha512-7jIQcnd8RnKsDt1IxmEjq9t7l5fnf0e5c+c1+1GjG4NR+TY0XkJcWtrBv0DWd65uAlDiQYMlEG8ls5dz1GQiuA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.0.tgz",
+      "integrity": "sha512-eKTvNXze2Fo7vAEjvJFIGn5QdU0OP4aD9DuT/uTBLRM1QS+ju7KtPITbVW+xgCviHLnOVeFQ1UsIs9kjkakD4g==",
       "requires": {
         "@terraformer/common": "^2.0.7"
       }
@@ -2356,9 +2356,10 @@
       }
     },
     "esri-leaflet": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.4.1.tgz",
-      "integrity": "sha512-0ukZIhA9dVx8yYe/ahp2yZm7GmUYTxPktXXHBVPBZoe9I00fkhLsEk2dIt1xa7XsCk/gH+Breb9L5lNALC+Niw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.3.tgz",
+      "integrity": "sha512-TTfUQ00r9dMVhb8ipTEIN/cF3SDvCQj2kQcmnwNyuFO5wcOM3y59ou3xwTMp5mMjpyYfelPl9s5LjosaqgxGaQ==",
+      "dev": true,
       "requires": {
         "@terraformer/arcgis": "^2.0.7",
         "tiny-binary-search": "^1.0.3"
@@ -2373,6 +2374,18 @@
         "esri-leaflet": "^2.0.0",
         "leaflet": "^1.0.0",
         "leaflet.markercluster": "^1.0.0"
+      },
+      "dependencies": {
+        "esri-leaflet": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.5.3.tgz",
+          "integrity": "sha512-zapunrhhhKyiVP5NCSfFjD7YqWYYYD3OONVjBFWZgX2KbD6ssUQ3KnXVo2U0hswWfJDIoHF7g9PLZ4rDNuQnvA==",
+          "optional": true,
+          "requires": {
+            "@terraformer/arcgis": "^2.0.7",
+            "tiny-binary-search": "^1.0.3"
+          }
+        }
       }
     },
     "estraverse": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "John Gravois <jgravois@esri.com>"
   ],
   "peerDependencies": {
-    "esri-leaflet": "2.x",
+    "esri-leaflet": "3.x",
     "leaflet": "1.x",
     "leaflet-shape-markers": "1.x"
   },
@@ -23,7 +23,7 @@
     "@rollup/plugin-node-resolve": "^7.1.3",
     "babelify": "^6.1.3",
     "chai": "3.5.0",
-    "esri-leaflet": "^2.4.1",
+    "esri-leaflet": "^3.0.2",
     "gh-release": "^3.5.0",
     "http-server": "^0.12.3",
     "karma": "^4.4.1",

--- a/src/EsriLeafletRenderers.js
+++ b/src/EsriLeafletRenderers.js
@@ -1,4 +1,5 @@
-export { version as VERSION } from '../package.json';
+import packageInfo from '../package.json';
+export var VERSION = packageInfo.version;
 
 export { Renderer } from './Renderers/Renderer';
 export { SimpleRenderer, simpleRenderer } from './Renderers/SimpleRenderer';


### PR DESCRIPTION
Fix Webpack 5 errors (blocks upgrade for projects which are using  Angular v12 ).

https://webpack.js.org/migrate/5/#cleanup-the-code

Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of import { version } from './package.json' use import package from './package.json'; const { version } = package