### PR TITLE
Fix issue with import when using webpack 5

### DIFF
--- a/src/EsriLeafletRenderers.js
+++ b/src/EsriLeafletRenderers.js
@@ -1,6 +1,8 @@
 import './FeatureLayerHook';
 
-export { version as VERSION } from '../package.json';
+import packageInfo from '../package.json';
+var version = packageInfo.version;
+export { version as VERSION };
 
 export { Renderer } from './Renderers/Renderer';
 export { SimpleRenderer, simpleRenderer } from './Renderers/SimpleRenderer';


### PR DESCRIPTION
@gavinr-maps Same [fix](https://github.com/Esri/Leaflet.shapeMarkers/pull/27) applied to [leaflet-shape-markers](https://github.com/Esri/Leaflet.shapeMarkers).
